### PR TITLE
Now we take object to be proxied instead of its id.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 0.3.1 - unreleased
 ------------------
 
-- No changes yet.
+- Now we take object to be proxied instead of its id.
 
 0.3.0 - 2015-10-05
 ------------------

--- a/kotti_content_proxy/resources.py
+++ b/kotti_content_proxy/resources.py
@@ -47,18 +47,18 @@ class ContentProxy(Content):
         addable_to=[u'Document'],
         )
 
-    def __init__(self, proxied_id=None, **kwargs):
+    def __init__(self, proxied_object=None, **kwargs):
         """ Constructor
 
-        :param proxied_id: id of the proxied object
-        :type proxied_id: int
+        :param proxied_object: proxied object
+        :type proxied_object: :class:`kotti.resources.Content`
 
         :param **kwargs: see :class:`kotti.resources.Content`
         :type **kwargs: variant
         """
 
         super(ContentProxy, self).__init__(**kwargs)
-        self.proxied_id = proxied_id
+        self.proxied_object = proxied_object
 
     def __getattribute__(self, key):
         """ Proxy some attributes.

--- a/kotti_content_proxy/resources.py
+++ b/kotti_content_proxy/resources.py
@@ -47,7 +47,7 @@ class ContentProxy(Content):
         addable_to=[u'Document'],
         )
 
-    def __init__(self, proxied_id=None, proxied_attrs=None, **kwargs):
+    def __init__(self, proxied_id=None, **kwargs):
         """ Constructor
 
         :param proxied_id: id of the proxied object

--- a/kotti_content_proxy/tests/conftest.py
+++ b/kotti_content_proxy/tests/conftest.py
@@ -16,7 +16,7 @@ def foo_proxy(root, db_session):
     db_session.flush()
 
     # create a proxy for the 'foo'
-    proxy = root[u'proxy'] = ContentProxy(proxied_id=foo.id, title=u'Proxy',
+    proxy = root[u'proxy'] = ContentProxy(proxied_object=foo, title=u'Proxy',
                                           description=u'This is a proxy')
     db_session.flush()
 

--- a/kotti_content_proxy/tests/test_models.py
+++ b/kotti_content_proxy/tests/test_models.py
@@ -8,7 +8,6 @@ def test_model(foo_proxy):
 
 
 def test_proxying_custom_attributes(foo_proxy):
-
     import kotti_content_proxy
 
     mock_settings = {

--- a/kotti_content_proxy/views.py
+++ b/kotti_content_proxy/views.py
@@ -6,9 +6,12 @@ Created on 2014-09-23
 """
 
 import colander
+
+from kotti.resources import Node
 from kotti.util import render_view
 from kotti.views.form import AddFormView
 from kotti.views.form import EditFormView
+
 from pyramid.response import Response
 from pyramid.view import view_config
 from pyramid.view import view_defaults
@@ -36,6 +39,12 @@ class ContentProxyAddForm(AddFormView):
     schema_factory = ContentProxySchema
     add = ContentProxy
     item_type = _(u"ContentProxy")
+
+    def save_success(self, appstruct):
+        proxied_id = appstruct.pop('proxied_id')
+        proxied_object = Node.query.filter(Node.id == proxied_id).one()
+        appstruct['proxied_object'] = proxied_object
+        return super(ContentProxyAddForm, self).save_success(appstruct)
 
 
 @view_config(context=ContentProxy, name='edit', permission='edit',


### PR DESCRIPTION
This is in line with philosophy of SQLAlchemy which tracks relations between _objects_ and updates respective properties and not the other way around. Setting only id of proxied object resulted (in some scenarios) in `proxied_object` being `None` while accessing proxied attribute and as a consequence `AttributeError`. See https://bitbucket.org/zzzeek/sqlalchemy/issues/1939/automatic-expiration-of-related-properties
